### PR TITLE
make modules public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,8 @@
    THE SOFTWARE.
 */
 
-mod ffi;
-mod error;
+pub mod ffi;
+pub mod error;
 
 use ffi::*;
 use std::ffi::{CStr, CString};


### PR DESCRIPTION
This will allow use of the ffi directly as well as use of the crate error type (allowing for foreign linking from error_chain)