### PR TITLE
Add shell32 library

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -46,6 +46,7 @@ fn main() {
         cfg.file(nfd!("nfd_win.cpp"));
         cfg.compile("libnfd.a");
         println!("cargo:rustc-link-lib=ole32");
+        println!("cargo:rustc-link-lib=shell32");
         // MinGW doesn't link it by default
         println!("cargo:rustc-link-lib=uuid");
     } else {


### PR DESCRIPTION
This was included by default for older Rust versions but is now needed explicitly as of 1.33.0.

Fixes #14