### PR TITLE
Update 3 year old nativefiledialog to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,4 @@ keywords = ["file", "dialog", "ui"]
 build = "build.rs"
 
 [build-dependencies]
-gcc = "0.3"
-
+cc = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -20,7 +20,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-extern crate gcc;
+extern crate cc;
+
 use std::env;
 use std::process::Command;
 
@@ -31,7 +32,7 @@ macro_rules! nfd {
 }
 
 fn main() {
-    let mut cfg = gcc::Config::new();
+    let mut cfg = cc::Build::new();
     let env = env::var("TARGET").unwrap();
 
     cfg.include(nfd!("include"));


### PR DESCRIPTION
This updates from using nativefiledialog C library from 2016-08-25 to latest master, version 1.1.6 from 2019-09-30.

No code changes required!

Would be great to publish a new version of this crate with this to include the 3 years of fixes and updates